### PR TITLE
feat: unify throwable printing

### DIFF
--- a/bukkit/src/main/java/studio/mevera/imperat/BukkitImperat.java
+++ b/bukkit/src/main/java/studio/mevera/imperat/BukkitImperat.java
@@ -233,7 +233,7 @@ public final class BukkitImperat extends BaseImperat<BukkitSource> {
                 return jar.getEntry("paper-plugin.yml") != null;
             }
         } catch (IOException | URISyntaxException e) {
-            e.printStackTrace();
+            config().getThrowablePrinter().print(e);
             return false;
         }
     }

--- a/bukkit/src/main/java/studio/mevera/imperat/brigadier/BukkitBrigadierManager.java
+++ b/bukkit/src/main/java/studio/mevera/imperat/brigadier/BukkitBrigadierManager.java
@@ -19,7 +19,7 @@ public final class BukkitBrigadierManager extends BaseBrigadierManager<BukkitSou
 
     public BukkitBrigadierManager(BukkitImperat dispatcher) {
         super(dispatcher);
-        this.commodore = CommodoreProvider.getCommodore(dispatcher.getPlatform());
+        this.commodore = CommodoreProvider.getCommodore(dispatcher);
         if (isSupported()) {
             registerArgumentResolver(String.class, DefaultArgTypeResolvers.STRING);
             registerArgumentResolver(DefaultArgTypeResolvers.NUMERIC);

--- a/bukkit/src/main/java/studio/mevera/imperat/commodore/LegacyPaperCommodore.java
+++ b/bukkit/src/main/java/studio/mevera/imperat/commodore/LegacyPaperCommodore.java
@@ -41,14 +41,18 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.function.Predicate;
+import studio.mevera.imperat.BukkitImperat;
 
 @SuppressWarnings("ALL")
 final class LegacyPaperCommodore extends AbstractCommodore implements Listener {
 
     private final List<CommodoreCommand> commands = new ArrayList<>();
+    private final BukkitImperat imperat;
 
-    LegacyPaperCommodore(Plugin plugin) throws ClassNotFoundException {
+    LegacyPaperCommodore(BukkitImperat imperat) throws ClassNotFoundException {
         Class.forName("com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent");
+        this.imperat = imperat;
+        Plugin plugin = imperat.getPlatform();
         plugin.getServer().getPluginManager().registerEvents(this, plugin);
     }
 
@@ -67,7 +71,7 @@ final class LegacyPaperCommodore extends AbstractCommodore implements Listener {
         try {
             setRequiredHackyFieldsRecursively(node, DUMMY_SUGGESTION_PROVIDER);
         } catch (Throwable e) {
-            e.printStackTrace();
+            imperat.config().getThrowablePrinter().print(e);
         }
 
         Collection<String> aliases = getAliases(command);

--- a/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
+++ b/core/src/main/java/studio/mevera/imperat/ConfigBuilder.java
@@ -56,6 +56,17 @@ public abstract class ConfigBuilder<S extends Source, I extends Imperat<S>, B ex
     }
 
     /**
+     * Sets the {@link ThrowablePrinter} used to print unhandled exceptions.
+     *
+     * @param printer the printer to use
+     * @return the current builder instance for chaining
+     */
+    public B throwablePrinter(ThrowablePrinter printer) {
+        config.setThrowablePrinter(printer);
+        return (B) this;
+    }
+
+    /**
      * Sets a custom {@link PermissionChecker} to determine and resolve permissions
      * for the command sender/source within the platform's configuration.
      *

--- a/core/src/main/java/studio/mevera/imperat/ImperatConfig.java
+++ b/core/src/main/java/studio/mevera/imperat/ImperatConfig.java
@@ -57,6 +57,18 @@ public sealed interface ImperatConfig<S extends Source> extends
     String commandPrefix();
 
     void setCommandPrefix(String cmdPrefix);
+
+    /**
+     * @return the printer used for unhandled throwables
+     */
+    @NotNull ThrowablePrinter getThrowablePrinter();
+
+    /**
+     * Sets the printer used for unhandled throwables.
+     *
+     * @param printer the throwable printer to use
+     */
+    void setThrowablePrinter(@NotNull ThrowablePrinter printer);
     
     /**
      * Fetches {@link ParameterType} for a certain value

--- a/core/src/main/java/studio/mevera/imperat/ImperatConfigImpl.java
+++ b/core/src/main/java/studio/mevera/imperat/ImperatConfigImpl.java
@@ -81,6 +81,8 @@ final class ImperatConfigImpl<S extends Source> implements ImperatConfig<S> {
     private PermissionLoader<S> permissionLoader = PermissionLoader.defaultLoader();
     private NodePermissionAssigner<S> permissionAssigner = NodePermissionAssigner.defaultAssigner();
     private HelpCoordinator<S> helpCoordinator = HelpCoordinator.create();
+
+    private ThrowablePrinter throwablePrinter = ThrowablePrinter.simple();
     
     ImperatConfigImpl() {
         contextResolverRegistry = ContextResolverRegistry.createDefault();
@@ -793,7 +795,17 @@ final class ImperatConfigImpl<S extends Source> implements ImperatConfig<S> {
     public void setInstanceFactory(InstanceFactory<S> factory) {
         this.instanceFactory = factory;
     }
-    
+
+    @Override
+    public @NotNull ThrowablePrinter getThrowablePrinter() {
+        return throwablePrinter;
+    }
+
+    @Override
+    public void setThrowablePrinter(@NotNull ThrowablePrinter printer) {
+        this.throwablePrinter = printer;
+    }
+
     @Override
     public <E extends Throwable> boolean handleExecutionThrowable(@NotNull E throwable, Context<S> context, Class<?> owning, String methodName) {
         
@@ -812,7 +824,7 @@ final class ImperatConfigImpl<S extends Source> implements ImperatConfig<S> {
         //Trying to handle the error from the Central Throwable Handler.
         var res = ImperatConfig.super.handleExecutionThrowable(throwable, context, owning, methodName);
         if(!res) {
-            ImperatDebugger.error(owning, methodName, throwable);
+            throwablePrinter.print(throwable);
         }
         return true;
     }

--- a/core/src/main/java/studio/mevera/imperat/ThrowablePrinter.java
+++ b/core/src/main/java/studio/mevera/imperat/ThrowablePrinter.java
@@ -1,0 +1,73 @@
+package studio.mevera.imperat;
+
+import org.jetbrains.annotations.NotNull;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Strategy interface responsible for printing throwables that are
+ * caught but not otherwise handled.
+ *
+ * <p>This allows platforms to customise how unhandled exceptions are
+ * presented, whether by logging frameworks, plain printing, or other
+ * mechanisms.</p>
+ */
+@FunctionalInterface
+public interface ThrowablePrinter {
+
+    /**
+     * Prints the stacktrace for the given throwable.
+     *
+     * @param throwable the throwable to print
+     */
+    void print(@NotNull Throwable throwable);
+
+    /**
+     * Returns a simple printer that logs the throwable using the
+     * {@code IMPERAT} logger.
+     *
+     * @return a basic throwable printer
+     */
+    static @NotNull ThrowablePrinter simple() {
+        return throwable -> Logger.getLogger("IMPERAT")
+            .log(Level.SEVERE, "Unhandled exception", throwable);
+    }
+
+    /**
+     * Returns a printer that formats the throwable into a decorative box
+     * and logs it using the {@code IMPERAT} logger.
+     *
+     * @return a boxed throwable printer
+     */
+    static @NotNull ThrowablePrinter box() {
+        return throwable -> Logger.getLogger("IMPERAT")
+            .severe(formatThrowable(throwable));
+    }
+
+    private static @NotNull String formatThrowable(@NotNull Throwable throwable) {
+        StringBuilder sb = new StringBuilder();
+        String exceptionName = throwable.getClass().getSimpleName();
+        String message = throwable.getMessage() != null ? throwable.getMessage() : "No message";
+
+        sb.append("┌─ 🚨 ").append(exceptionName).append(' ')
+            .append("─".repeat(Math.max(0, 40 - exceptionName.length()))).append("┐");
+        sb.append(System.lineSeparator()).append("│ ").append(message);
+
+        for (StackTraceElement element : throwable.getStackTrace()) {
+            sb.append(System.lineSeparator()).append("│ → ")
+                .append(element.getClassName().substring(element.getClassName().lastIndexOf('.') + 1))
+                .append('.').append(element.getMethodName())
+                .append("() @ line ").append(element.getLineNumber());
+        }
+
+        sb.append(System.lineSeparator()).append("└").append("─".repeat(45)).append("┘");
+
+        if (throwable.getCause() != null) {
+            sb.append(System.lineSeparator()).append("🔗 Caused by:")
+                .append(System.lineSeparator())
+                .append(formatThrowable(throwable.getCause()));
+        }
+
+        return sb.toString();
+    }
+}

--- a/core/src/main/java/studio/mevera/imperat/annotations/base/element/ThrowableParsingVisitor.java
+++ b/core/src/main/java/studio/mevera/imperat/annotations/base/element/ThrowableParsingVisitor.java
@@ -52,7 +52,7 @@ final class ThrowableParsingVisitor<S extends Source> extends CommandClassVisito
             return new MethodThrowableResolver<>(caller, exceptionType);
         } catch (Throwable e) {
             ImperatDebugger.warning("Failed to register throwable-method '" + methodElement.getName() + "' in class '" + owner.getChildren() + "'");
-            e.printStackTrace();
+            imperat.config().getThrowablePrinter().print(e);
             return null;
         }
     }

--- a/core/src/test/java/studio/mevera/imperat/tests/enhanced/EnhancedErrorValidationTest.java
+++ b/core/src/test/java/studio/mevera/imperat/tests/enhanced/EnhancedErrorValidationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import studio.mevera.imperat.ThrowablePrinter;
 import studio.mevera.imperat.context.ExecutionResult;
 import studio.mevera.imperat.exception.ImperatException;
 import studio.mevera.imperat.tests.TestSource;
@@ -23,7 +24,7 @@ class EnhancedErrorValidationTest extends EnhancedBaseImperatTest {
             try {
                 execute("completely_unknown_command with args");
             }catch (Exception ex) {
-                ex.printStackTrace();
+                ThrowablePrinter.simple().print(ex);
                 Assertions.assertInstanceOf(IllegalArgumentException.class, ex);
             }
         }

--- a/core/src/test/java/studio/mevera/imperat/tests/errors/ErrorHandlingTest.java
+++ b/core/src/test/java/studio/mevera/imperat/tests/errors/ErrorHandlingTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import studio.mevera.imperat.ThrowablePrinter;
 import studio.mevera.imperat.context.ExecutionResult;
 import studio.mevera.imperat.tests.BaseImperatTest;
 import studio.mevera.imperat.tests.ImperatTestGlobals;
@@ -28,7 +29,7 @@ public class ErrorHandlingTest extends BaseImperatTest {
         try{
             execute("completely_unknown_command with args");
         }catch (Exception ex) {
-            ex.printStackTrace();
+            ThrowablePrinter.simple().print(ex);
             Assertions.assertInstanceOf(IllegalArgumentException.class, ex);
         }
     }
@@ -95,7 +96,7 @@ public class ErrorHandlingTest extends BaseImperatTest {
     void testPermissions1() {
         ExecutionResult<TestSource> result = execute((src)-> src.withPerm("testperm.use"),"testperm hi bye"); // Should fail due to missing Group context
         assertNotNull(result.getError());
-        result.getError().printStackTrace();
+        ThrowablePrinter.simple().print(result.getError());
     }*/
    /*
     @Test
@@ -104,7 +105,7 @@ public class ErrorHandlingTest extends BaseImperatTest {
         ExecutionResult<TestSource> result = execute((src)-> src.withPerm("testperm.use"), "testperm a b"); // Should fail due to missing Group context
         assertFailure(result, PermissionDeniedException.class);
         assertNotNull(result.getError());
-        result.getError().printStackTrace();
+        ThrowablePrinter.simple().print(result.getError());
     }
     
     @Test


### PR DESCRIPTION
## Summary
- rename `StacktraceFormatter` to `ThrowablePrinter`
- expose `ThrowablePrinter` via config and builder
- replace direct stacktrace printing with `ThrowablePrinter` across modules
- add `ThrowablePrinter.box()` for decorative boxed output
- log default printers through the IMPERAT logger instead of `System.err`
- route Bukkit commodore stack traces through `ImperatConfig`'s `ThrowablePrinter`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_b_68b7b6e4a1c083278c29f913274e1ec7