### PR TITLE
Fix imperat CLI not properly handling unknown commands 

### DIFF
--- a/cli/src/main/java/studio/mevera/imperat/CommandLineImperat.java
+++ b/cli/src/main/java/studio/mevera/imperat/CommandLineImperat.java
@@ -86,23 +86,23 @@ public final class CommandLineImperat extends BaseImperat<ConsoleSource> {
      * Wraps a sender object into a ConsoleSource.
      * For CLI applications, all sources are console sources.
      *
-     * @param sender the sender object (typically a PrintStream)
+     * @param sender the sender object (typically a ConsoleLogger)
      * @return a new ConsoleSource wrapping the sender
      */
     @Override
     public ConsoleSource wrapSender(Object sender) {
-        return new ConsoleSource((PrintStream) sender);
+        return new ConsoleSource((ConsoleLogger) sender);
     }
 
     /**
      * Dispatches the command-line from the input stream provided
      *
-     * @param outputStream the output stream/command-source origin
+     * @param consoleLogger the console logger to write to
      */
-    public void dispatch(OutputStream outputStream) {
+    public void dispatch(ConsoleLogger consoleLogger) {
         try (BufferedReader reader = new BufferedReader(new InputStreamReader(input))) {
             String line = reader.readLine();
-            ConsoleSource prompt = wrapSender(outputStream);
+            ConsoleSource prompt = wrapSender(consoleLogger);
             super.execute(prompt, line);
         } catch (IOException e) {
             throw new RuntimeException(e);
@@ -111,11 +111,20 @@ public final class CommandLineImperat extends BaseImperat<ConsoleSource> {
 
     /**
      * Dispatches the command-line from the input stream provided
-     * while using {@link System#out} as an {@link OutputStream}
      *
+     * @param outputStream the output stream/command-source origin
+     * @deprecated Use {@link #dispatch(ConsoleLogger)} instead
      */
-    public void dispatch() {
-        dispatch(System.out);
+    @Deprecated
+    public void dispatch(OutputStream outputStream) {
+        dispatch(ConsoleLogger.SYSTEM);
     }
 
+    /**
+     * Dispatches the command-line from the input stream provided
+     * while using {@link ConsoleLogger#SYSTEM} for output.
+     */
+    public void dispatch() {
+        dispatch(ConsoleLogger.SYSTEM);
+    }
 }

--- a/cli/src/main/java/studio/mevera/imperat/ConsoleLogger.java
+++ b/cli/src/main/java/studio/mevera/imperat/ConsoleLogger.java
@@ -1,0 +1,53 @@
+package studio.mevera.imperat;
+
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Represents a simple console logger invoked by {@link studio.mevera.imperat.context.Source}
+ * output methods (e.g. {@code Source#reply}, {@code Source#error}).
+ * <p>
+ * Applications may implement their preferred solution, such as Java's
+ * {@link java.util.logging.Logger} or SLF4J.
+ */
+public interface ConsoleLogger {
+
+    ConsoleLogger SYSTEM = new SystemConsoleLogger();
+
+    /**
+     * Logs an info message.
+     *
+     * @param message to log as info
+     */
+    void info(@NotNull String message);
+
+    /**
+     * Logs an error message.
+     *
+     * @param message to log as error
+     */
+    void error(@NotNull String message);
+
+    /**
+     * Logs a warning message.
+     * <p>
+     * Applications may override this method with a proper warning logger.
+     *
+     * @param message to log as warning
+     */
+    default void warn(@NotNull String message) {
+        info("WARN: " + message);
+    }
+
+    class SystemConsoleLogger implements ConsoleLogger {
+
+        @Override
+        public void info(@NotNull String message) {
+            System.out.println(message);
+        }
+
+        @Override
+        public void error(@NotNull String message) {
+            System.err.println(message);
+        }
+    }
+}

--- a/cli/src/main/java/studio/mevera/imperat/ConsoleSource.java
+++ b/cli/src/main/java/studio/mevera/imperat/ConsoleSource.java
@@ -32,15 +32,15 @@ import java.io.PrintStream;
  */
 public class ConsoleSource implements Source {
 
-    private final PrintStream outputStream;
+    private final ConsoleLogger consoleLogger;
 
     /**
      * Creates a new ConsoleSource that outputs to the specified PrintStream.
      *
-     * @param outputStream the PrintStream to write output to (e.g., System.out)
+     * @param consoleLogger the logger to write output to (e.g., ConsoleLogger.SYSTEM)
      */
-    public ConsoleSource(final PrintStream outputStream) {
-        this.outputStream = outputStream;
+    public ConsoleSource(final ConsoleLogger consoleLogger) {
+        this.consoleLogger = consoleLogger;
     }
 
     /**
@@ -55,13 +55,13 @@ public class ConsoleSource implements Source {
     }
 
     /**
-     * Gets the original PrintStream that this ConsoleSource wraps.
+     * Gets the original ConsoleLogger that this ConsoleSource wraps.
      *
-     * @return the underlying PrintStream
+     * @return the underlying ConsoleLogger
      */
     @Override
-    public PrintStream origin() {
-        return outputStream;
+    public ConsoleLogger origin() {
+        return consoleLogger;
     }
 
     /**
@@ -71,29 +71,29 @@ public class ConsoleSource implements Source {
      */
     @Override
     public void reply(final String message) {
-        outputStream.println(message);
+        consoleLogger.info(message);
     }
 
     /**
-     * Sends a warning message to the console output stream.
+     * Sends a warning message to the console logger.
      * Warning messages are prefixed with "[WARN]".
      *
      * @param message the warning message to send
      */
     @Override
     public void warn(final String message) {
-        outputStream.println("[WARN] " + message);
+        consoleLogger.warn(message);
     }
 
     /**
-     * Sends an error message to the console output stream.
+     * Sends an error message to the console logger.
      * Error messages are prefixed with "[ERROR]".
      *
      * @param message the error message to send
      */
     @Override
     public void error(final String message) {
-        outputStream.println("[ERROR] " + message);
+        consoleLogger.error(message);
     }
 
     /**

--- a/core/src/main/java/studio/mevera/imperat/BaseImperat.java
+++ b/core/src/main/java/studio/mevera/imperat/BaseImperat.java
@@ -347,7 +347,7 @@ public abstract class BaseImperat<S extends Source> implements Imperat<S> {
     public @NotNull ExecutionResult<S> execute(@NotNull S source, @NotNull String commandName, String[] rawInput)  {
         Command<S> command = getCommand(commandName);
         if (command == null) {
-            throw new IllegalArgumentException("Unknown command input: '" + commandName + "'");
+            throw new UnknownCommandException(commandName);
         }
         return execute(source, command, commandName, rawInput);
     }

--- a/core/src/main/java/studio/mevera/imperat/ImperatConfigImpl.java
+++ b/core/src/main/java/studio/mevera/imperat/ImperatConfigImpl.java
@@ -104,6 +104,12 @@ final class ImperatConfigImpl<S extends Source> implements ImperatConfig<S> {
 
     private void regDefThrowableResolvers() {
 
+        // This throwable resolver is intended for CLI applications that lack a low-level command dispatcher
+        // to validate whether a command exists. It is needed for non-minecraft java applications.
+        this.setThrowableResolver(UnknownCommandException.class, (exception, context) -> {
+            context.source().error("No command named '" + exception.getCommand() + "' is registered");
+        });
+
         this.setThrowableResolver(InvalidSourceException.class, (exception, context) -> {
             throw new UnsupportedOperationException("Couldn't find any source resolver for valueType `"
                 + exception.getTargetType().getTypeName() + "'");

--- a/core/src/main/java/studio/mevera/imperat/exception/UnknownCommandException.java
+++ b/core/src/main/java/studio/mevera/imperat/exception/UnknownCommandException.java
@@ -1,0 +1,17 @@
+package studio.mevera.imperat.exception;
+
+import org.jetbrains.annotations.NotNull;
+
+public class UnknownCommandException extends RuntimeException {
+
+    private final String command;
+
+    public UnknownCommandException(String command) {
+        this.command = command;
+    }
+
+    @NotNull
+    public String getCommand() {
+        return command;
+    }
+}


### PR DESCRIPTION
This PR:
- Fixes an ``IllegalArgumentException`` thrown when executing an unknown command for CLI applications.
- Adds polymorphic logger support for the console, allowing developers to use or implement their preferred logging solution, such as Java's Logger or SLF4J.